### PR TITLE
Fix: 메인 페이지 뒤로 가기 작동 안되는 버그 해결

### DIFF
--- a/coding-mate/src/components/page/MainBox.js
+++ b/coding-mate/src/components/page/MainBox.js
@@ -283,7 +283,7 @@ export default function MainBox() {
   };
 
   const handleBackButtonClick = () => {
-    navigate("/");
+    navigate("/login");
   };
 
   return (
@@ -302,7 +302,7 @@ export default function MainBox() {
           position: "absolute",
           top: "3%",
           left: -6,
-          zIndex: 1,
+          zIndex: 9999,
         }}
       >
         <button


### PR DESCRIPTION
## 📕 이슈 번호
- close #69 
- (경원님이 부탁하신 내용)

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 메인 페이지 상에서 뒤로 가기 버튼이 클릭이 되지 않아 로그인 페이지로 이동이 안되었는데 이 부분을 해결하였습니다. 

